### PR TITLE
Move to followees only queue

### DIFF
--- a/cmd/discover/main.go
+++ b/cmd/discover/main.go
@@ -61,13 +61,13 @@ func main() {
 		logger.WithError(err).Fatal("could not create dqueue for userOnboarding")
 	}
 
-	userFollowerQueue, err := queue.NewDQueue(
-		"userFollower.queue",
+	userFolloweeQueue, err := queue.NewDQueue(
+		"userFollowee.queue",
 		cfg.QueueStoreDir,
-		&model.UserFollowerTask{},
+		&model.UserFolloweeTask{},
 	)
 	if err != nil {
-		logger.WithError(err).Fatal("could not create dqueue for userFollower")
+		logger.WithError(err).Fatal("could not create dqueue for userFollowee")
 	}
 
 	userQueue, err := queue.NewDQueue(
@@ -113,7 +113,7 @@ func main() {
 		neo,
 		prv,
 		userOnboardingQueue,
-		userFollowerQueue,
+		userFolloweeQueue,
 		userQueue,
 		repositoryQueue,
 	)

--- a/internal/crawler/crawler.go
+++ b/internal/crawler/crawler.go
@@ -152,9 +152,9 @@ func (c *Crawler) handleUserFolloweeTask(task *model.UserFolloweeTask) error {
 	// TODO check if we've already processed this user in last n hours
 
 	// follow back user
-	if err := c.provider.FollowUser(ctx, task.Name); err != nil {
-		// TODO return errors.Wrap(err, "could not follow back user")
-	}
+	// if err := c.provider.FollowUser(ctx, task.Name); err != nil {
+	// TODO return errors.Wrap(err, "could not follow back user")
+	// }
 
 	// fetch user's starred repos
 	stars, err := c.provider.GetUserStars(ctx, task.Name)

--- a/internal/model/user_followee_task.go
+++ b/internal/model/user_followee_task.go
@@ -1,0 +1,6 @@
+package model
+
+// UserFolloweeTask represents a task in the userFollowee queue
+type UserFolloweeTask struct {
+	Name string
+}

--- a/internal/model/user_follower_task.go
+++ b/internal/model/user_follower_task.go
@@ -1,6 +1,0 @@
-package model
-
-// UserFollowerTask represents a task in the userFollower queue
-type UserFollowerTask struct {
-	Name string
-}


### PR DESCRIPTION
This renames the FollowersQueue to FolloweesQueue which treats, both the followers of the bot and the followees of each follower, the same.

For each entry in the queue, it will:
- Follow back
- Fetch it's starred repos (this will be moved to another queue that will be fed by the Bot's main actual feed, that's why we are following people back)
- Fetch it's own repos (TODO same with above)
- Store in DB